### PR TITLE
Enforce initial delay delay

### DIFF
--- a/addon/services/events-service.ts
+++ b/addon/services/events-service.ts
@@ -113,7 +113,7 @@ export default class EventsService extends Service {
 
   private _backoffDelay(attempt: number): number {
     if (attempt === 0) {
-      return 0;
+      return 200;
     }
     return Math.min(Math.exp(attempt) * 1000 + this._jitterDelay, 60000);
   }

--- a/addon/services/events-service.ts
+++ b/addon/services/events-service.ts
@@ -66,13 +66,13 @@ export default class EventsService extends Service {
 
   private _tryConnect(): void {
     const delay = this._backoffDelay(this._attempt);
-    console.info(`Attempting connection n°${this._attempt + 1} after a delay of ${delay / 1000}s`);
     this._attempt++;
 
     later(
       this,
       () => {
         try {
+          console.info(`Attempting connection n°${this._attempt + 1} after a delay of ${delay / 1000}s`);
           this._connect();
         } catch (e) {
           console.error(`Could not establish connection: ${e}`);


### PR DESCRIPTION
### What does this PR do?

In an attempt to limit the double connection issue. 
- Let's enforce a minimal initial delay of 200ms in order to let the browser handle all the app initialization events
- Log only when we're really attempting the double connection, this way we will be able to say if we're duplicating on the same attempt somehow.