### PR TITLE
Fixed: deprecation on getWithDefault

### DIFF
--- a/addon/configuration.ts
+++ b/addon/configuration.ts
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import { getWithDefault } from '@ember/object';
 import { typeOf } from '@ember/utils';
 
 const DEFAULTS = {
@@ -17,9 +16,9 @@ export default {
       // eslint-disable-next-line no-prototype-builtins
       if (this.hasOwnProperty(property) && typeOf(this[property]) !== 'function') {
         if (this[property].constructor == Object) {
-          this[property] = Object.assign(this[property], getWithDefault(config, property, DEFAULTS[property]));
+          this[property] = Object.assign(this[property], config[property] ?? DEFAULTS[property]);
         } else {
-          this[property] = getWithDefault(config, property, DEFAULTS[property]);
+          this[property] = config[property] ?? DEFAULTS[property];
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Replaced deprecated method getWithDefault.

Related to: #[VEL-3592](https://linear.app/upfluence/issue/VEL-3592/httpsdeprecationsemberjscomv3xtoc-ember-metal-get-with-default)

### What are the observable changes?

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled
