### PR TITLE
Add immediate option to log

### DIFF
--- a/addon/services/activity-tracking.ts
+++ b/addon/services/activity-tracking.ts
@@ -21,14 +21,18 @@ const RETRY_ATTEMPTS: number = 1;
 const THROTTLE_TIME_MS = 1000;
 const DEFAULT_LOG_OPTIONS = {
   immediate: false
-}
+};
 
 export default class ActivityTracking extends Service {
   @service declare session: any;
   @tracked activityQueue: Activity[] = [];
 
-
-  log(type: ActivityType, action: string, extra: Record<string, unknown> = {}, options: {immediate?:boolean} = DEFAULT_LOG_OPTIONS): void {
+  log(
+    type: ActivityType,
+    action: string,
+    extra: Record<string, unknown> = {},
+    options: { immediate?: boolean } = DEFAULT_LOG_OPTIONS
+  ): void {
     const logOptions = { ...DEFAULT_LOG_OPTIONS, ...options };
     this.activityQueue.push(this.buildActivityObject(type, action, extra));
     debounce(this, this.performCall, THROTTLE_TIME_MS, logOptions.immediate);

--- a/addon/services/activity-tracking.ts
+++ b/addon/services/activity-tracking.ts
@@ -19,14 +19,19 @@ export type Activity = {
 
 const RETRY_ATTEMPTS: number = 1;
 const THROTTLE_TIME_MS = 1000;
+const DEFAULT_LOG_OPTIONS = {
+  immediate: false
+}
 
 export default class ActivityTracking extends Service {
   @service declare session: any;
   @tracked activityQueue: Activity[] = [];
 
-  log(type: ActivityType, action: string, extra: Record<string, unknown> = {}): void {
+
+  log(type: ActivityType, action: string, extra: Record<string, unknown> = {}, options: {immediate?:boolean} = DEFAULT_LOG_OPTIONS): void {
+    const logOptions = { ...DEFAULT_LOG_OPTIONS, ...options };
     this.activityQueue.push(this.buildActivityObject(type, action, extra));
-    debounce(this, this.performCall, THROTTLE_TIME_MS);
+    debounce(this, this.performCall, THROTTLE_TIME_MS, logOptions.immediate);
   }
 
   private performCall(tries: number = RETRY_ATTEMPTS, retryActivityQueue?: Activity[]): void {


### PR DESCRIPTION
### What does this PR do?
Sometimes browser redirections are done before the end of the debounce delay, for example when redirecting to auth flows for Tiktok and Instagram. 
To avoid this, this PR adds an immediate option to the activityTracking log method, that executes immediately the debounce function.
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled
