### PR TITLE
Update Activity-tracking service with better handling of extra parameter

### DIFF
--- a/addon/services/activity-tracking.ts
+++ b/addon/services/activity-tracking.ts
@@ -17,8 +17,8 @@ export type Activity = {
   extra?: Record<string, string>;
 };
 
+export const THROTTLE_TIME_MS = 1000;
 const RETRY_ATTEMPTS: number = 1;
-const THROTTLE_TIME_MS = 1000;
 const DEFAULT_LOG_OPTIONS = {
   immediate: false
 };

--- a/addon/services/activity-tracking.ts
+++ b/addon/services/activity-tracking.ts
@@ -14,7 +14,7 @@ export type Activity = {
   route: string;
   origin?: string;
   version?: string;
-  extra?: {};
+  extra?: Record<string, string>;
 };
 
 const RETRY_ATTEMPTS: number = 1;
@@ -83,8 +83,12 @@ export default class ActivityTracking extends Service {
       path: window.location.pathname + window.location.search,
       action: action,
       version: (getOwnConfig() as any).parentAppVersion || 'unknown',
-      extra: extra
+      extra: this.stringifyExtra(extra)
     };
+  }
+
+  private stringifyExtra(extra: Record<string, unknown>): Record<string, string> {
+    return Object.fromEntries(Object.entries(extra).map(([key, value]) => [key, String(value)]));
   }
 }
 

--- a/tests/unit/services/activity-tracking-test.ts
+++ b/tests/unit/services/activity-tracking-test.ts
@@ -1,11 +1,65 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import { THROTTLE_TIME_MS } from '@upfluence/hyperevents/services/activity-tracking';
 
 module('Unit | Service | activity-tracking', function (hooks) {
   setupTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.service = this.owner.lookup('service:activity-tracking');
+    this.service.session = {
+      data: { authenticated: { access_token: 'mocked-access-token' } }
+    };
+    this.clock = sinon.useFakeTimers();
+    this.fetchStub = sinon.stub(window, 'fetch').resolves({ ok: true, json: () => Promise.resolve() } as Response);
+  });
+
+  hooks.afterEach(function () {
+    this.clock.runAll();
+    this.clock.restore();
+    this.fetchStub.restore();
+  });
+
   test('it exists', function (assert) {
     let service = this.owner.lookup('service:activity-tracking');
     assert.ok(service);
+  });
+
+  test('it stringifies extra values', function (assert) {
+    this.service.log('page_view', 'test-action', {
+      text: 'hello',
+      count: 3,
+      ok: true,
+      nil: null,
+      missing: undefined,
+      obj: { a: 1 },
+      arr: [1, 2]
+    });
+
+    let [activity] = this.service.activityQueue;
+    assert.deepEqual(activity.extra, {
+      text: 'hello',
+      count: '3',
+      ok: 'true',
+      nil: 'null',
+      missing: 'undefined',
+      obj: '[object Object]',
+      arr: '1,2'
+    });
+  });
+
+  test('it enqueues activities and sends them in bulk after the delay', function (assert) {
+    this.service.log('page_view', 'test-action-1', {});
+    this.service.log('button_click', 'test-action-2', {});
+    this.service.log('button_click', 'test-action-3', {});
+
+    assert.equal(this.fetchStub.callCount, 0, 'fetch should not be called immediately');
+    this.clock.tick(THROTTLE_TIME_MS);
+    assert.equal(this.fetchStub.callCount, 1, 'fetch should be called after throttle time');
+    const [url, options] = this.fetchStub.firstCall.args;
+    assert.equal(url, `${this.service.apiUrl}`, 'fetch should be called with correct URL');
+    const body = JSON.parse(options.body);
+    assert.equal(body.activities.length, 3, 'fetch should be called with all enqueued activities');
   });
 });


### PR DESCRIPTION
### What does this PR do?

Update Activity-tracking service with better handling of extra parameter:

The API side of the activity tracking only accepts an `extra` paramter of type `Record<string, string>`.
Before this PR, our typing of this parameter was `Record<string, unknown>`, in which nothing would prevent us from assigning a `number` type for example. This usage causes an API error though.

This PR ensures that the `extra` parameters are always serialized to strings before triggering the call:
- Simple values (string, number, boolean, null, undefined) are coerced to their string equivalents.
- Complex values (objects/arrays) are not preserved structurally and will serialize to their default string form (e.g. "[object Object]" or comma-joined arrays). There is no usage of this in the codebase AFAIK, so nothing will break. It'll be the dev's responsability if trying to put a complex type - but I don't see any reason why we would want to use it this way.

The input type of the `log` method has not been updated to prevent TS errors in other projects (read -> I don't have the time to double check everywhere)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled