### PR TITLE
Activity tracking: Remove private declaration for buildActivityObject

### DIFF
--- a/addon/services/activity-tracking.ts
+++ b/addon/services/activity-tracking.ts
@@ -38,7 +38,7 @@ export default class ActivityTracking extends Service {
     debounce(this, this.performCall, THROTTLE_TIME_MS, logOptions.immediate);
   }
 
-  buildActivityObject(type: ActivityType, action: string, extra: Record<string, unknown>): Activity {
+  protected buildActivityObject(type: ActivityType, action: string, extra: Record<string, unknown>): Activity {
     return {
       type: type,
       origin: window.location.origin,

--- a/addon/services/activity-tracking.ts
+++ b/addon/services/activity-tracking.ts
@@ -38,6 +38,18 @@ export default class ActivityTracking extends Service {
     debounce(this, this.performCall, THROTTLE_TIME_MS, logOptions.immediate);
   }
 
+  buildActivityObject(type: ActivityType, action: string, extra: Record<string, unknown>): Activity {
+    return {
+      type: type,
+      origin: window.location.origin,
+      route: getOwner(this).lookup('service:router').currentRouteName,
+      path: window.location.pathname + window.location.search,
+      action: action,
+      version: (getOwnConfig() as any).parentAppVersion || 'unknown',
+      extra: this.stringifyExtra(extra)
+    };
+  }
+
   private performCall(tries: number = RETRY_ATTEMPTS, retryActivityQueue?: Activity[]): void {
     if (this.activityQueue.length === 0 && !retryActivityQueue) return;
     const tempActivityQueue: Activity[] = retryActivityQueue ?? [...this.activityQueue];
@@ -75,17 +87,7 @@ export default class ActivityTracking extends Service {
     return this.session.data.authenticated.access_token;
   }
 
-  private buildActivityObject(type: ActivityType, action: string, extra: Record<string, unknown>): Activity {
-    return {
-      type: type,
-      origin: window.location.origin,
-      route: getOwner(this).lookup('service:router').currentRouteName,
-      path: window.location.pathname + window.location.search,
-      action: action,
-      version: (getOwnConfig() as any).parentAppVersion || 'unknown',
-      extra: this.stringifyExtra(extra)
-    };
-  }
+
 
   private stringifyExtra(extra: Record<string, unknown>): Record<string, string> {
     return Object.fromEntries(Object.entries(extra).map(([key, value]) => [key, String(value)]));


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[PYX-160](https://linear.app/upfluence/issue/PYX-160/groundwork-handling-mixpanel-events)

### What are the observable changes?
- Remove private declaration for buildActivityObject to allow ember app override this behavior
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:

- Feel free to migrate existing components to Glimmer Components.
- Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled
